### PR TITLE
fix: use domain-based lookup for ACM validation options instead of index

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -13,13 +13,20 @@ data "aws_secretsmanager_secret_version" "cloudflare_api_token" {
 }
 
 locals {
-  domains = keys(var.dns_records)
+  validation_map = {
+    for dv in var.acm_certificate.domain_validation_options :
+    dv.domain_name => {
+      name  = dv.resource_record_name
+      value = dv.resource_record_value
+      type  = dv.resource_record_type
+    }
+  }
   validation_records = {
-    for idx, domain in local.domains : domain => {
+    for domain, config in var.dns_records : domain => {
       zone_id = data.cloudflare_zone.zone[domain].zone_id
-      name    = trimsuffix(var.acm_certificate.domain_validation_options[idx].resource_record_name, ".")
-      value   = trimsuffix(var.acm_certificate.domain_validation_options[idx].resource_record_value, ".")
-      type    = var.acm_certificate.domain_validation_options[idx].resource_record_type
+      name    = trimsuffix(local.validation_map[domain].name, ".")
+      value   = trimsuffix(local.validation_map[domain].value, ".")
+      type    = local.validation_map[domain].type
     }
   }
 


### PR DESCRIPTION
**Context:**

The previous implementation used index-based lookup which failed when:
- ACM returned validation options in a different order than input domains
- ACM generated extra validation entries (wildcards, base domains)
- The number of validation options didn't match the number of DNS records

**Changes:**

Keys are replaced by a lookup map keyed by domain name, ensuring each domain
gets the correct validation record regardless of ACM's ordering or the
number of entries returned.